### PR TITLE
null path with no body fix.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <groupId>org.zoomba-lang</groupId>
     <artifactId>spark-core</artifactId>
     <packaging>bundle</packaging>
-    <version>3.0</version>
+    <version>3.0.1-SNAPSHOT</version>
     <name>Spark</name>
     <description>A micro framework for creating web applications in Kotlin and Java 8 with minimal effort</description>
     <url>http://www.sparkjava.com</url>

--- a/pom.xml
+++ b/pom.xml
@@ -32,13 +32,14 @@
         <java.version>17</java.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <jetty.version>11.0.19</jetty.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jetty.version>11.0.22</jetty.version>
         <powermock.version>1.7.4</powermock.version>
         <mockito.version>1.10.19</mockito.version>
+        <sl4j.version>2.1.0-alpha1</sl4j.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.javadoc.skip>false</maven.javadoc.skip>
-        <gpg.skip>false</gpg.skip>
-        <deploy.skip>false</deploy.skip>
+        <gpg.skip>true</gpg.skip>
+        <deploy.skip>true</deploy.skip>
     </properties>
 
     <distributionManagement>
@@ -61,13 +62,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.7</version>
+            <version>${sl4j.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.7</version>
+            <version>${sl4j.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -141,7 +142,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.10.1</version>
+            <version>2.11.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -267,6 +268,17 @@
                 <extensions>true</extensions>
             </plugin>
             <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>3.1.1</version>
@@ -274,7 +286,24 @@
                     <skip>${deploy.skip}</skip>
                 </configuration>
             </plugin>
-
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>10.0.2</version>
+                <configuration>
+                    <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                    <nvdApiKey>77a5db4a-b0c6-43f6-9035-bef3207bbd2f</nvdApiKey>
+                    <autoUpdate>true</autoUpdate>
+                    <skip>false</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/main/java/spark/http/matching/Routes.java
+++ b/src/main/java/spark/http/matching/Routes.java
@@ -27,6 +27,8 @@ import spark.routematch.RouteMatch;
  */
 final class Routes {
 
+    private static final org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(Routes.class);
+
     static void execute(RouteContext context) throws Exception {
 
         Object content = context.body().get();
@@ -59,6 +61,10 @@ final class Routes {
                 context.responseWrapper().setDelegate(context.response());
 
                 Object element = route.handle(context.requestWrapper(), context.responseWrapper());
+                if ( element == null && context.response().body() == null ){ // A misbehaving route returning null???
+                    LOG.warn( "route {} produced 'null', will replace with string 'null'", route.getPath());
+                    element = "null" ;
+                }
                 if (!context.responseWrapper().isRedirected()) {
                 	result = route.render(element);
                 }

--- a/src/test/java/spark/NullRetPathTest.java
+++ b/src/test/java/spark/NullRetPathTest.java
@@ -1,0 +1,38 @@
+package spark;
+
+import org.junit.*;
+import spark.util.SparkTestUtil;
+
+import static spark.Service.ignite;
+
+public class NullRetPathTest {
+
+    private static final int SOME_PORT = 8888;
+    private static Service service;
+
+    @BeforeClass
+    public static void setUpClass() {
+        service = ignite();
+        service.port(SOME_PORT);
+        service.get("/null", (q, a) ->  {
+            a.status(200);
+            return null;
+        });
+        service.init();
+        service.awaitInitialization();
+    }
+
+    @Test
+    public void testNullReturningPath() throws Exception {
+        SparkTestUtil testUtil = new SparkTestUtil(SOME_PORT);
+        SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/does_not_exist", null);
+        Assert.assertEquals(404, response.status);
+        response = testUtil.doMethod("GET", "/null", null);
+        Assert.assertEquals(200, response.status);
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        service.stop();
+    }
+}


### PR DESCRIPTION
Fixing the issue that when response is null, and body() is not set, `404` gets generated.
https://github.com/nmondal/spark-11/issues/3
