### PR TITLE
Bump jetty version due to CVE-2024-22201

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <java.version>17</java.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <jetty.version>11.0.19</jetty.version>
+        <jetty.version>11.0.20</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <powermock.version>1.7.4</powermock.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
In the `org.eclipse.jetty.http2:http2-common` package there is a `Uncontrolled Resource Consumption ('Resource Exhaustion')` caused by the following dependency chain: `org.zoomba-lang:spark-core@3.0` -> `org.eclipse.jetty.http2:http2-server@11.0.19` -> `org.eclipse.jetty.http2:http2-common@11.0.19`

A patch is available in the jetty version `11.0.20`.

This PR should fix the issue #7 