### PR TITLE
fix: Only change the matched route when request delegate exists

### DIFF
--- a/src/main/java/spark/http/matching/BeforeFilters.java
+++ b/src/main/java/spark/http/matching/BeforeFilters.java
@@ -38,13 +38,17 @@ final class BeforeFilters {
             Object filterTarget = filterMatch.getTarget();
 
             if (filterTarget instanceof FilterImpl) {
-                Request request = RequestResponseFactory.create(filterMatch, context.httpRequest());
 
-                FilterImpl filter = (FilterImpl) filterTarget;
+                if (context.requestWrapper().getDelegate() == null) {
+                    Request request = RequestResponseFactory.create(filterMatch, context.httpRequest());
+                    context.requestWrapper().setDelegate(request);
+                } else {
+                    context.requestWrapper().changeMatch(filterMatch);
+                }
 
-                context.requestWrapper().setDelegate(request);
                 context.responseWrapper().setDelegate(context.response());
 
+                FilterImpl filter = (FilterImpl) filterTarget;
                 filter.handle(context.requestWrapper(), context.responseWrapper());
 
                 String bodyAfterFilter = context.response().body();


### PR DESCRIPTION
When a filter read the body of the request, the following filters can not get the body.