### PR TITLE
Revert the JettyHandler implementation

### DIFF
--- a/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
+++ b/src/main/java/spark/embeddedserver/jetty/EmbeddedJettyServer.java
@@ -134,7 +134,7 @@ public class EmbeddedJettyServer extends VirtualThreadAware.Proxy implements Emb
         final ServletContextHandler servletContextHandler = webSocketServletContextHandler == null ?
             new ServletContextHandler() : webSocketServletContextHandler;
 
-        final SessionHandler sessionHandler = new SessionHandler();
+        final JettyHandler sessionHandler = new JettyHandler(matcherFilter);
         sessionHandler.getSessionCookieConfig().setHttpOnly(httpOnly);
         servletContextHandler.setSessionHandler(sessionHandler);
 

--- a/src/main/java/spark/embeddedserver/jetty/JettyHandler.java
+++ b/src/main/java/spark/embeddedserver/jetty/JettyHandler.java
@@ -1,0 +1,39 @@
+package spark.embeddedserver.jetty;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.eclipse.jetty.ee10.servlet.ServletContextRequest;
+import org.eclipse.jetty.ee10.servlet.SessionHandler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+
+/**
+ * Simple Jetty Handler
+ *
+ * @author Per Wendel
+ */
+public class JettyHandler extends SessionHandler {
+    private final Filter filter;
+
+    public JettyHandler(Filter filter) {
+        this.filter = filter;
+    }
+
+    @Override
+    public boolean handle(Request request, Response response, Callback callback) throws Exception {
+        if (request instanceof ServletContextRequest servletContextRequest) {
+            final HttpServletResponse httpServletResponse = servletContextRequest.getHttpServletResponse();
+            final HttpServletRequest httpServletRequest = servletContextRequest.getServletApiRequest();
+            final HttpRequestWrapper wrapper = new HttpRequestWrapper(httpServletRequest);
+
+            filter.doFilter(wrapper, httpServletResponse, null);
+            callback.succeeded();
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Hello everyone,  

Thank you for your efforts in maintaining this Spark project.  

Recently, when I tried switching Spark to this repository, I encountered an issue while retrieving the request body using:  
`spark.Request#body`  

I have a `Filter` used for logging, which looks like this:  

```java
public class LoggingRequestFilter implements Filter {
    @Override
    public void handle(Request request, Response response) {
        System.out.println("Log body: " + request.body());
    }
}
```

The body value is successfully retrieved and logged correctly.  

However, in another part of the logic,  inside a `spark.Route` implementation (e.g., `UserRoute implements Route`), calling `spark.Request.body()` always returns `null`.  
(The reason is that the `InputStream` body has already been consumed in `LoggingRequestFilter`.)  

After debugging the issue, I found that since this PR:  
- https://github.com/nmondal/spark-11/pull/11

This PR removed the `JettyHandler` implementation (which included the `HttpRequestWrapper` delegate logic).  

Here is my PR to revert wrapper logic change.  

I am a newbie to this project, so please feel free to provide any feedback.

Regards,
Tung
